### PR TITLE
recipes-kernel: add zephyr license

### DIFF
--- a/recipes-kernel/zephyr-kernel/zephyr-milkv-duo.inc
+++ b/recipes-kernel/zephyr-kernel/zephyr-milkv-duo.inc
@@ -1,5 +1,7 @@
 include recipes-kernel/zephyr-kernel/zephyr-sample.inc
 
+LICENSE = "Apache-2.0"
+
 DEPENDS:append = " dtc-native"
 
 SRCREV_milkv = "master"


### PR DESCRIPTION
fixes 

```
ERROR: ../sources/meta-milkv/recipes-kernel/zephyr-kernel/zephyr-openamp-rsc-table.bb: This recipe does not have the LICENSE field set (zephyr-openamp-rsc-table)
ERROR: Parsing halted due to errors, see error messages above
ERROR: ../sources/meta-milkv/recipes-kernel/zephyr-kernel/zephyr-blinky.bb: This recipe does not have the LICENSE field set (zephyr-blinky)
```

btw: thx for the nice work <3